### PR TITLE
Patched the depreciated variable names in tests and user examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Last Updated
 
-January 25, 2023
+February 26, 2023
 
 ## Build Status
 

--- a/test/tests/kernels/simple_reaction/obstruction_reaction.i
+++ b/test/tests/kernels/simple_reaction/obstruction_reaction.i
@@ -99,13 +99,6 @@
     type = GAnisotropicDiffusion
     variable = conc
   [../]
-  #Reaction kernel only applies to the system boundaries
-  #   Thus, this kernel is meant to emulate a surface reaction
-  #[./rxn_conc]
-  #  type = CoefReaction
-  #  variable = conc
-  #  coefficient = 1.0
-  #[../]
 
   #Coupled Reaction and time derivatives
   [./coupled_dot]
@@ -132,7 +125,7 @@
     variable = p
     u = vel_x
     v = vel_y
-    p = p
+    pressure = p
   [../]
 
   #Conservation of momentum equ in x (with time derivative)
@@ -145,7 +138,7 @@
     variable = vel_x
     u = vel_x
     v = vel_y
-    p = p
+    pressure = p
     component = 0
   [../]
 
@@ -159,7 +152,7 @@
     variable = vel_y
     u = vel_x
     v = vel_y
-    p = p
+    pressure = p
     component = 1
   [../]
 []
@@ -278,7 +271,6 @@
   [./inlet_func]
     type = ParsedFunction
     #Parabola that has velocity of zero at y=top and=bot, with maximum at y=middle
-    #value = a*y^2 + b*y + c	solve for a, b, and c
     value = '-0.25 * y^2 + 1'
   [../]
 []

--- a/user_examples/INS_2D_flow_over_step.i
+++ b/user_examples/INS_2D_flow_over_step.i
@@ -308,7 +308,6 @@
   [./inlet_func]
     type = ParsedFunction
     #Parabola that has velocity of zero at y=top and=bot, with maximum at y=middle
-    #value = a*y^2 + b*y + c	solve for a, b, and c
     value = '10.0*(1-exp(-1*t))'   #in cm/s
     # Velocities in cm/s
   [../]


### PR DESCRIPTION
Fixes the recent CI failures due to depreciated variable names in MOOSE Navier-Stokes module. 